### PR TITLE
Changing the git clone instructions to work on machines without ful git setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Project Insight 2016.
 2. Download and Install [Vagrant](https://www.vagrantup.com/downloads.html) (Version 1.7.4 has been verified as of 2016-02-05)
 
 ## Usage
-1. After cloning this repository `git clone git@github.com:KareemSaleh/insight.git insight` change into the root directory and run `vagrant up`
+1. After cloning this repository `git clone https://github.com/KareemSaleh/insight.git insight` change into the root directory and run `vagrant up`
 2. After the virtual machine has finished booting up you should be able to navagate to `http://127.0.0.1:8888` to verify that it is working.
 
 ## Tests


### PR DESCRIPTION
I got following error while cloning on a machine without git credentials setup:

```
Cloning into 'insight'...
The authenticity of host 'github.com (192.30.252.128)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.252.128' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
