### PR TITLE
Enforce LF line endings even on Windows. CRLF breaks BASH scripts there.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior, in case people have core.autocrlf set.
+# Enforce LF even on Windows, CRLF usually breaks BASH scripts
+
+* text=auto eol=lf

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,11 @@ Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
   config.vm.define "insight" do |insight|
-    config.vm.box = "hashicorp/precise64"
-    config.vm.provision :shell, name: "setup", path: "bootstrap.sh"
-    config.vm.network :forwarded_port, guest: 80, host: 8888
-    config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
-    config.vm.post_up_message = "Welcome to Project Insight 2016. Visit 'http://127.0.0.1:8888' in your browser to begin.\n" +
+    insight.vm.box = "hashicorp/precise64"
+    insight.vm.provision :shell, name: "setup", path: "bootstrap.sh"
+    insight.vm.network :forwarded_port, guest: 80, host: 8888
+    insight.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+    insight.vm.post_up_message = "Welcome to Project Insight 2016. Visit 'http://127.0.0.1:8888' in your browser to begin.\n" +
       "To begin the test go to 'http://127.0.0.1:8888/users/add' in your browser."
   end
 end


### PR DESCRIPTION
Hi, 

envvars script can't be read properly on Linux machines when containing CRLF line endings. This usually happens with Git on Windows when core.autocrlf setting is turned on. It causes machine not to start properly and without stack running. 

Pepa
